### PR TITLE
Fix pytest plugins not running on src

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,4 +15,4 @@ known_first_party=mmemoji
 
 [tool:pytest]
 addopts = --verbose
-testpaths = tests
+python_files = tests/*.py


### PR DESCRIPTION
The plugins were only checking the test suite. :(