### PR TITLE
Upgrade pytest-black to >=0.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
       secure: 2H8Xu2tDpeWtTGoxvMHaWfz8Uc16FSyPT+8kJHM0FSJhAgt1lI6vh8MlGDtQlNfG95HMQ1LhidNfu2re/QEiFpnDofaAQWQR0WdrnJjrsFTltwRDbfe0kgEitC9FC3E5Y/JPWDey5VHOxeJtdApXwloWKwbsN0Ww5zdF+Z25ZsS0bfmevxTaBZsyVNxTJzuX7g8dAlvFRlZU2oyzxODI092WJ+4eb9z0oEXQfyZsqmhQmRFDGDFVcRrLyG4Gut9nxHeaj7IspX3NTclN2ECssIQugfnERiYQN7qygRYzN3Bev69Fb98OJrRBxZYFLArAJOO6MW3PJDOVZwYkYW1kMiOrx7+Mz6CTFmeTw7T3t0IOulsQa/ud75oJFGYliAgqC53KrDICxmOrV1Q/bTqIffV5wOTJXq0JYHKvgkbLH7a9LIPXAvVL4aK/Ww5ba1vsYdw4nlX3PfUFopGtQwUBV66FeXkg30gWH/JzSfaJIVqJdlos6QsTpBKWWyL48vqYaVTdn0Z5lQ/DCohbMvMLHurtTNFcIEGzDMI4JvmfnwYSIVK8pJTlqAqNT9lFJswWLCL6uy2gIGS7TmUubipvA86LwCH9/8P2VALEF+0GP9prfZwZHXQJ0KgSsc7B2Ik3Khei5qEHeOVohQ3ZqJXPZ5BWJuMC7H0aHsCf+GRxdFg=
 
 install:
-  - pip install . 'black ; python_version>="3.6"'
+  - pip install .
 
 script:
   - python setup.py test --addopts \

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     setup_requires=["pytest-runner"],
     tests_require=[
         "pytest",
-        "pytest-black ; python_version>='3.6'",
+        "pytest-black>=0.3.3 ; python_version>='3.6'",
         "pytest-cov",
         "pytest-flake8",
         "pytest-isort",


### PR DESCRIPTION
The plugin doesn't require `black` to be available in `PATH` anymore.