### PR TITLE
Improve sanitization of emoji names when there are accents

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "requests",
         "tablib",
         "tabulate",
+        "unidecode",
     ],
     entry_points={"console_scripts": ["mmemoji = mmemoji.cli:cli"]},
     setup_requires=["pytest-runner"],

--- a/src/mmemoji/emoji.py
+++ b/src/mmemoji/emoji.py
@@ -8,6 +8,7 @@ This wrapper is built around ``python-mattermostdriver``_
 
 import re
 from os.path import basename
+import unidecode
 
 from mattermostdriver.exceptions import ResourceNotFound
 
@@ -50,6 +51,9 @@ class Emoji:
         name = basename(filepath).split(".")[0]
         # Remove parentheses
         name = re.sub(r"[()[\]{}]", "", name)
+
+        # sanitize name to ascii (removes accents)
+        name = unidecode.unidecode(name)
         # Replace forbidden characters by underscores
         name = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
         return name


### PR DESCRIPTION
This creates a better result when there are accents.

Example, instead of translating "Zé.png" to "Z_" the result is "Ze".