### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] - 2022-03-27
 ### Changed
 - Drop support for Python 3.6 which [has reached end-of-life](https://www.python.org/dev/peps/pep-0494/) ([#80])
+- Drop `tablib` dependency. Support JSON and table outputs only ([#88])
+
+### Fixed
+- Set minimum dependencies versions ([#90])
 
 ## [0.3.1] - 2021-10-17
 ### Fixed
@@ -43,12 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/maxbrunet/mmemoji/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/maxbrunet/mmemoji/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/maxbrunet/mmemoji/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/maxbrunet/mmemoji/compare/v0.2.0...v0.3.1
 [0.3.0]: https://github.com/maxbrunet/mmemoji/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/maxbrunet/mmemoji/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/maxbrunet/mmemoji/releases/tag/v0.1.0
 
+[#90]: https://github.com/maxbrunet/mmemoji/issues/90
+[#88]: https://github.com/maxbrunet/mmemoji/issues/88
 [#80]: https://github.com/maxbrunet/mmemoji/issues/80
 [#23]: https://github.com/maxbrunet/mmemoji/issues/23
 [#20]: https://github.com/maxbrunet/mmemoji/issues/20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "mmemoji"
-version = "0.3.1"
+version = "0.4.0"
 description = "Custom Emoji manager command-line for Mattermost 😎"
 readme = "README.md"
 authors = []


### PR DESCRIPTION
### Changed
- Drop support for Python 3.6 which [has reached end-of-life](https://www.python.org/dev/peps/pep-0494/) ([#80])
- Drop `tablib` dependency. Support JSON and table outputs only ([#88])

### Fixed
- Set minimum dependencies versions ([#90])

[0.4.0]: https://github.com/maxbrunet/mmemoji/compare/v0.3.1...v0.4.0

[#90]: https://github.com/maxbrunet/mmemoji/issues/90
[#88]: https://github.com/maxbrunet/mmemoji/issues/88
[#80]: https://github.com/maxbrunet/mmemoji/issues/80