### PR TITLE
fix: Address code smells

### DIFF
--- a/src/mmemoji/cli.py
+++ b/src/mmemoji/cli.py
@@ -18,7 +18,7 @@ class EmojiCLI(click.MultiCommand):
             os.path.join(os.path.dirname(__file__), "commands")
         )
         for filename in os.listdir(cmd_folder):
-            if filename.endswith(".py") and not filename == "__init__.py":
+            if filename.endswith(".py") and filename != "__init__.py":
                 rv.append(filename[:-3])
         rv.sort()
         return rv

--- a/tests/test_commands_download.py
+++ b/tests/test_commands_download.py
@@ -82,9 +82,7 @@ def test_download_emoji_to_full_path(
         assert hashlib.sha256(f.read()).hexdigest() == emoji_sha256
 
 
-def test_download_emoji_to_non_existing(
-    cli_runner: CliRunner, tmp_path: Path
-) -> None:
+def test_download_emoji_to_non_existing(cli_runner: CliRunner) -> None:
     # Setup
     destination = os.path.join("path", "that", "does", "not", "exists")
     emoji_name = "emoji_1"


### PR DESCRIPTION
* Use the opposite operator ("!=") instead of "not" and "=="
* Remove the unused function parameter "tmp_path"