### PR TITLE
feat: support for Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
 
     timeout-minutes: 15
 
@@ -80,6 +81,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
 
     timeout-minutes: 15
 
@@ -148,7 +150,7 @@ jobs:
     timeout-minutes: 15
 
     env:
-      PYTHON_VERSION: '3.10'
+      PYTHON_VERSION: '3.11'
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Allow running Python module as script: `python -m mmemoji` ([#94])
+- Support for Python 3.11 ([#206])
 
 ## [0.4.0] - 2022-03-27
 ### Changed
@@ -58,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/maxbrunet/mmemoji/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/maxbrunet/mmemoji/releases/tag/v0.1.0
 
+[#206]: https://github.com/maxbrunet/mmemoji/issues/206
 [#94]: https://github.com/maxbrunet/mmemoji/issues/94
 [#90]: https://github.com/maxbrunet/mmemoji/issues/90
 [#88]: https://github.com/maxbrunet/mmemoji/issues/88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow running Python module as script: `python -m mmemoji` ([#94])
 - Support for Python 3.11 ([#206])
 
+### Changed
+- Replace [deprecated `imghdr` module](https://peps.python.org/pep-0594/#deprecated-modules) by [`filetype`](https://pypi.org/project/filetype) package ([#206])
+
 ## [0.4.0] - 2022-03-27
 ### Changed
 - Drop support for Python 3.6 which [has reached end-of-life](https://www.python.org/dev/peps/pep-0494/) ([#80])

--- a/poetry.lock
+++ b/poetry.lock
@@ -89,6 +89,14 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "filetype"
+version = "1.1.0"
+description = "Infer file type and MIME type of any file/buffer. No external dependencies."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "flake8"
 version = "5.0.4"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -436,7 +444,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "54ad114311481ad0fad662f598ad503f7f9995a7fe500667d811a9430f51c1bc"
+content-hash = "feff74a6c27e442ea9e055221bd5a546cda4f117ddb8dbcf0ccf140f347a4440"
 
 [metadata.files]
 attrs = [
@@ -533,6 +541,10 @@ coverage = [
     {file = "coverage-6.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987"},
     {file = "coverage-6.5.0-pp36.pp37.pp38-none-any.whl", hash = "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a"},
     {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
+]
+filetype = [
+    {file = "filetype-1.1.0-py2.py3-none-any.whl", hash = "sha256:117e25a50988d1a03a32ed510f4a15353e7291e683e94c63930497dd2c66ce24"},
+    {file = "filetype-1.1.0.tar.gz", hash = "sha256:afe4a00029601f66d239b72688065cc7c219dec1c927994f90b825e9e53d8f93"},
 ]
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ relative_files = true
 
 [tool.black]
 line-length = 79
-target_version = ["py37", "py38", "py39", "py310"]
+target_version = ["py37", "py38", "py39", "py310", "py311"]
 
 [tool.isort]
 profile = "black"
@@ -56,6 +56,7 @@ classifiers=[
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Utilities",
 ]
 keywords = ["cli", "emoji", "mattermost"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ license = "GPLv3"
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 click = ">=8.0.0"
+filetype = ">=0.1.3"
 importlib-metadata = { version = ">=1.4.0", python = "<3.8" }
 mattermostdriver = ">=6.1.2"
 mypy-extensions = ">=0.4.3"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.coverage.exclusions=tests/**/*
 sonar.organization=maxbrunet-github
 sonar.projectKey=maxbrunet_mmemoji
-sonar.python.version=3.7, 3.8, 3.9, 3.10
+sonar.python.version=3.7, 3.8, 3.9, 3.10, 3.11
 sonar.sources=.

--- a/src/mmemoji/commands/download.py
+++ b/src/mmemoji/commands/download.py
@@ -1,8 +1,8 @@
-import imghdr
 import os
 from typing import Any, List
 
 import click
+from filetype import filetype
 from requests import HTTPError
 
 from mmemoji import Emoji
@@ -73,7 +73,8 @@ def cli(
                 filename = destination
             else:
                 filename = os.path.join(
-                    destination, "{}.{}".format(name, imghdr.what(None, image))
+                    destination,
+                    "{}.{}".format(name, filetype.guess_extension(image)),
                 )
 
             if os.path.exists(filename) and (


### PR DESCRIPTION
* Support for Python 3.11
* Replace [deprecated `imghdr` module](https://peps.python.org/pep-0594/#deprecated-modules) by [`filetype`](https://pypi.org/project/filetype) package