### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0] - 2023-07-02
 ### Added
 - Allow running Python module as script: `python -m mmemoji` ([#94])
 - Support for Python 3.11 ([#206])
@@ -60,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/maxbrunet/mmemoji/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/maxbrunet/mmemoji/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/maxbrunet/mmemoji/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/maxbrunet/mmemoji/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/maxbrunet/mmemoji/compare/v0.2.0...v0.3.1
 [0.3.0]: https://github.com/maxbrunet/mmemoji/compare/v0.2.0...v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "mmemoji"
-version = "0.4.0"
+version = "0.5.0"
 description = "Custom Emoji manager command-line for Mattermost 😎"
 readme = "README.md"
 authors = []


### PR DESCRIPTION
### Added
- Allow running Python module as script: `python -m mmemoji` ([#94])
- Support for Python 3.11 ([#206])

### Changed
- Replace [deprecated `imghdr` module](https://peps.python.org/pep-0594/#deprecated-modules) by [`filetype`](https://pypi.org/project/filetype) package ([#206])
- Replace `format()` by f-strings ([#248])
- Improve typing with `ParamSpec` and more ([#253])

### Removed
- Drop support for Python 3.7 ([#320])

[#320]: https://github.com/maxbrunet/mmemoji/issues/320
[#253]: https://github.com/maxbrunet/mmemoji/issues/253
[#248]: https://github.com/maxbrunet/mmemoji/issues/248
[#206]: https://github.com/maxbrunet/mmemoji/issues/206
[#94]: https://github.com/maxbrunet/mmemoji/issues/94