### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0] - 2024-11-09
 ### Added
 - Support for Python 3.12 ([#405])
 - Support for Python 3.13 ([#709])
@@ -75,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/maxbrunet/mmemoji/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/maxbrunet/mmemoji/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/maxbrunet/mmemoji/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/maxbrunet/mmemoji/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/maxbrunet/mmemoji/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/maxbrunet/mmemoji/compare/v0.2.0...v0.3.1


### PR DESCRIPTION
### Added
- Support for Python 3.12 ([#405])
- Support for Python 3.13 ([#709])

### Changed
- Switch from `poetry` to `pdm` ([#457])
- Switch from `pdm` to `uv` ([#604])

### Fixed
- Enable more linting rules ([#444])

### Removed
- Drop support for Python 3.8 ([#709])

[#709]: https://github.com/maxbrunet/mmemoji/issues/709
[#604]: https://github.com/maxbrunet/mmemoji/issues/604
[#457]: https://github.com/maxbrunet/mmemoji/issues/457
[#444]: https://github.com/maxbrunet/mmemoji/issues/444
[#405]: https://github.com/maxbrunet/mmemoji/issues/405