### PR TITLE
build(deps): require click >=8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Replace `mypy` by `ty` for type checking ([#1260])
+- Require `click` >=8.4 ([#1278])
 
 ## [0.7.0] - 2025-11-29
 ### Added
@@ -110,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/maxbrunet/mmemoji/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/maxbrunet/mmemoji/releases/tag/v0.1.0
 
+[#1278]: https://github.com/maxbrunet/mmemoji/issues/1278
 [#1260]: https://github.com/maxbrunet/mmemoji/issues/1260
 [#1059]: https://github.com/maxbrunet/mmemoji/issues/1059
 [#1058]: https://github.com/maxbrunet/mmemoji/issues/1058

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ license = {text = "GPLv3"}
 dynamic = ["version"]
 requires-python = ">=3.10,<4.0"
 dependencies = [
-  "click>=8.2.0",
+  "click>=8.4.0",
   "filetype>=0.1.3",
   "httpx>=0.28.1",
   "mattermostautodriver>=10.12.0",

--- a/tests/test_commands_create.py
+++ b/tests/test_commands_create.py
@@ -173,8 +173,7 @@ class TestCreate:
                 input="yes\nno\n",
             )
         assert result.exit_code == 0
-        # Output contains the invocation input as well
-        emoji_list = json.loads("\n".join(result.stdout.split("\n")[3:]))
+        emoji_list = json.loads(result.stdout)
         emoji1 = cast(
             "dict[str, Any]",
             self.find_dict_in_list(emoji_list, "name", emoji_names[0]),

--- a/tests/test_commands_delete.py
+++ b/tests/test_commands_delete.py
@@ -101,8 +101,7 @@ class TestDelete:
                 input="yes\nno\n",
             )
         assert result.exit_code == 0
-        # Output contains the invocation input as well
-        emoji_list = json.loads("\n".join(result.stdout.split("\n")[3:]))
+        emoji_list = json.loads(result.stdout)
         assert len(emoji_list) == 1
         emoji1 = cast(
             "dict[str, Any]",

--- a/tests/test_commands_download.py
+++ b/tests/test_commands_download.py
@@ -187,8 +187,7 @@ class TestDownload:
                 ["download", "--interactive", *emoji_names, str(destination)],
                 input="yes\nno\n",
             )
-        # output is sliced to exclude input from it
-        paths = result.stdout.strip().split("\n")[0::2]
+        paths = result.stdout.strip().split("\n")
         assert result.exit_code == 0
         assert len(paths) == 2
         assert os.stat(destination / emoji_filenames[2]).st_size == 0

--- a/uv.lock
+++ b/uv.lock
@@ -191,14 +191,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -562,7 +562,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.2.0" },
+    { name = "click", specifier = ">=8.4.0" },
     { name = "filetype", specifier = ">=0.1.3" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mattermostautodriver", specifier = ">=10.12.0" },


### PR DESCRIPTION
Bug fix in readline for interactive prompts ([pallets/click#2969](https://redirect.github.com/pallets/click/pull/2969))